### PR TITLE
Add rabbitmq to volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,8 @@ services:
     # Replace with your domain name and replace --staging with --force-renewal after initial certificate has been issues
     command: certonly --webroot --webroot-path=/var/www/html --email your-email@domain.com --agree-tos --no-eff-email --staging -d basedash.fm
 volumes:
+  rabbitmq-data:
+  rabbitmq-logs:
   db:
   certbot-etc:
   certbot-var:


### PR DESCRIPTION
Resolves the following issue when running `docker-compose up`:

```
ERROR: Named volume "rabbitmq-data:/var/lib/rabbitmq:rw" is used in service "rabbitmq" but no declaration was found in the volumes section.
```